### PR TITLE
[3] Add copy to clipboard support to docs generator

### DIFF
--- a/tmpl/tmpl/docs/conf.py.jinja
+++ b/tmpl/tmpl/docs/conf.py.jinja
@@ -56,12 +56,6 @@ smv_remote_whitelist = "^origin$"
 #
 html_theme = 'furo'
 html_theme_options = {
-    "light_css_variables": {
-        "font-stack--monospace": "Fira Code, Cascadia Code, \"SFMono-Regular\", Menlo, Consolas, Monaco, Liberation Mono, Lucida Console, monospace",
-    },
-    "dark_css_variables": {
-        "font-stack--monospace": "Fira Code, Cascadia Code, \"SFMono-Regular\", Menlo, Consolas, Monaco, Liberation Mono, Lucida Console, monospace",
-    },
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/tmpl/tmpl/docs/conf.py.jinja
+++ b/tmpl/tmpl/docs/conf.py.jinja
@@ -31,7 +31,8 @@ release = '{{semver}}'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    "sphinx_multiversion",
+    'sphinx_copybutton',
+    'sphinx_multiversion',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -45,8 +46,8 @@ templates_path = [
 exclude_patterns = []
 
 smv_tag_whitelist = None
-smv_branch_whitelist = "^(master|release/v.+)$"
-smv_remote_whitelist = "^origin$"
+smv_branch_whitelist = '^(master|release/v.+)$'
+smv_remote_whitelist = '^origin$'
 
 
 # -- Options for HTML output -------------------------------------------------
@@ -60,7 +61,7 @@ html_theme_options = {
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
-# so a file named "default.css" will overwrite the builtin "default.css".
+# so a file named 'default.css' will overwrite the builtin 'default.css'.
 html_static_path = ['_static']
 html_css_files = [
     'css/custom.css',

--- a/tmpl/tmpl/docs/requirements.txt
+++ b/tmpl/tmpl/docs/requirements.txt
@@ -1,3 +1,4 @@
+sphinx-copybutton >= 0.5.0
 sphinx-multiversion >= 0.2.4
 Sphinx >= 5.0.2
 furo == 2022.6.21

--- a/tmpl/tmpl/docs/requirements.txt
+++ b/tmpl/tmpl/docs/requirements.txt
@@ -1,3 +1,3 @@
 sphinx-multiversion >= 0.2.4
-Sphinx >= 4.4.0
-furo == 2022.2.14.1
+Sphinx >= 5.0.2
+furo == 2022.6.21


### PR DESCRIPTION
Incorporate feedback from actual usage.
* Adds the `sphinx-copybutton` extension to the docs template
* Update sphinx dependencies.
* Fix a styling issue introduced by ligature fonts.

Fixes #3