### PR TITLE
Update Sphinx and GitHub Actions versions to latest

### DIFF
--- a/tmpl/tmpl/.github/workflows/gh-pages.yml
+++ b/tmpl/tmpl/.github/workflows/gh-pages.yml
@@ -13,33 +13,18 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.9"
-
-      - name: Upgrade pip
-        run: |
-          # install pip=>20.1 to use "pip cache dir"
-          python3 -m pip install --upgrade pip
-
-      - name: Get pip cache dir
-        id: pip-cache
-        run: echo "::set-output name=dir::$(pip cache dir)"
-
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-              ${{ runner.os }}-pip-
+          cache: 'pip'
+          cache-dependency-path: docs/requirements.txt
 
       - name: Install dependencies
         run: python3 -m pip install -r ./docs/requirements.txt

--- a/tmpl/tmpl/docs/requirements.txt
+++ b/tmpl/tmpl/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx-copybutton >= 0.5.0
-sphinx-multiversion >= 0.2.4
-Sphinx >= 5.0.2
-furo == 2022.6.21
+sphinx-copybutton ~= 0.5.0
+sphinx-multiversion ~= 0.2.4
+Sphinx ~= 5.3
+furo == 2022.9.29


### PR DESCRIPTION
- Update the referenced python packages and GitHub Actions.
- Replace the manual CI python package caching with the integrated one from `setup-python`.

These changes have been backported from deeplex/concrete#15